### PR TITLE
Add link to instructions how to add repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # hassio-addons
 Repository for hass.io add-ons
 
-For information about the HASS Configurator Hass.IO add-on have a look at https://github.com/danielperna84/hassio-addons/blob/master/hass-configurator/README.md  
-The original and standalone version of the HASS Configurator can be found at https://github.com/danielperna84/hass-configurator
+ - [Instructions how to add this repository to Hass.io](https://home-assistant.io/hassio/installing_third_party_addons/)
+ - For information about the HASS Configurator Hass.IO add-on have a look at https://github.com/danielperna84/hassio-addons/blob/master/hass-configurator/README.md  
+ - The original and standalone version of the HASS Configurator can be found at https://github.com/danielperna84/hass-configurator


### PR DESCRIPTION
Just a small tweak to add a link to instructions so people know how to add the repository to Hass.io